### PR TITLE
Fix digest error; v0.1.1

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -14,7 +14,8 @@ Suggests:
     covr,
     knitr,
     rmarkdown,
-    datasets
+    datasets,
+    digest
 RoxygenNote: 7.1.0
 Imports: 
     stats,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: distplyr
 Type: Package
 Title: Manipulation of Univariate Distributions
-Version: 0.1.0.9000
+Version: 0.1.1
 Authors@R: person("Vincenzo", "Coia", email = "vincenzo.coia@stat.ubc.ca",
                   role = c("aut", "cre"))
 Description: Provides an interface for invoking and maipulating

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,15 @@
+# distplyr 0.1.1
+
+This patch both fixes some problems in the previous release, as well as offering a step towards a bigger expansion.
+
+- Some change in the functional representations: 
+	- Changed random number generation from `randfn`, a functional representation, to the `realise()` and `realize()` functions. 
+	- Changed `probfn` representation to be more specific: `pmf` or `density`
+- Added the `enframe` suite of functions.
+- Implement the beginnings of being able to specify your own distribution, with the `set_` suite of functions, after making an empty distribution with `dst()`. 
+
+Additionally, there's some internal rearrangement, where the `get` functions call the `eval` functions, not vice versa.
+
 # distplyr 0.1.0
 
 The first version of `distplyr` is now available! Its functionality is rather limited at the moment, but is still useful, especially for its capability to handle a discrete component of a distribution. Here are the main features:


### PR DESCRIPTION
Fixing the error:

```
devtools::install_github('vincenzocoia/distplyr')
Error in loadNamespace(j <- i[[1L]], c(lib.loc, .libPaths()), versionCheck = vI[[j]]) : 
  there is no package called 'digest'
```

And, releasing v0.1.1